### PR TITLE
Improved training for inpainting gan model

### DIFF
--- a/gantools/model.py
+++ b/gantools/model.py
@@ -380,6 +380,16 @@ class InpaintingGAN(WGAN):
         self._inputs = (self.z, self.borders)
         self._outputs = (self.X_fake)
 
+    def batch2dict(self, batch):
+        d = dict()
+        d['X_real'] = self.assert_image(batch[:len(batch)//2])
+        d['X_to_inpaint'] = self.assert_image(batch[len(batch)//2:])
+        d['z'] = self.sample_latent(len(batch))
+        return d
+
+    def sample_latent(self, bs=1):
+        return super().sample_latent(int(bs//2))
+	
     def _build_generator(self):
         shape = self._params['shape']
         self.X_real = tf.placeholder(tf.float32, shape=[None, *shape], name='Xreal')
@@ -388,12 +398,12 @@ class InpaintingGAN(WGAN):
             shape=[None, self.params['generator']['latent_dim']],
             name='z')
 
-        borderleft, self.center_real, borderright = tf.split(self.X_real, self.params['inpainting']['split'], axis=1)
+        self.X_to_inpaint = tf.placeholder(tf.float32, shape=[None, *shape], name='XtoInpaint')
+        borderleft, self.center_real, borderright = tf.split(self.X_to_inpaint, self.params['inpainting']['split'], axis=1)
         borders = tf.concat([borderleft,borderright], axis=self.data_size+1)
         inshape = borders.shape.as_list()[1:]
 
         self.borders = tf.placeholder_with_default(borders, shape=[None, *inshape], name='borders')
-
 
         self.X_fake_center = self.generator(self.z,  y=self.borders, reuse=False)
         # Those line should be done in a better way


### PR DESCRIPTION
This change splits the batch in two. The inpainting model will inpaint a half of the batch, and use the other half as 'real' signals. 
I'm not sure if this will work for 1D, see the usage of the 'assert_image' method.